### PR TITLE
Adding support for Surface Model representations

### DIFF
--- a/src/ifc-to-three.js/geometry-generator/geometry-map.js
+++ b/src/ifc-to-three.js/geometry-generator/geometry-map.js
@@ -2,7 +2,7 @@ import { geometryTypes as g, namedProps as n } from '../../utils/global-constant
 import { mapCurve2D } from './ifc-curve2d.js';
 import { mapExtrudedAreaSolid, mapSweptSolid } from './ifc-sweptSolid.js';
 import { mapMappedRepresentation } from './ifc-mappedRepresentation.js';
-import { mapBrep } from './ifc-brep.js';
+import { mapBrep, mapSurfaceModel } from './ifc-brep.js';
 import { mapGeometricSet } from './ifc-geometricSet.js';
 import { mapClipping } from './ifc-clipping.js';
 
@@ -14,6 +14,7 @@ const geometryMap = {
   [g.geometricSet]: mapGeometricSet,
   [g.clipping]: mapClipping,
   [g.extrudedAreaSolid]: mapExtrudedAreaSolid,
+  [g.surfaceModel]: mapSurfaceModel
 };
 
 function getMappedGeometry(representation, product) {

--- a/src/ifc-to-three.js/geometry-generator/ifc-brep.js
+++ b/src/ifc-to-three.js/geometry-generator/ifc-brep.js
@@ -5,8 +5,21 @@ import { createFace } from "./three-shapeGeometry.js";
 function mapBrep(shape, product) {
   const representations = shape[n.items];
   const definitions = [];
+  representations.forEach((r) => definitions.push(...getGeometry(r[n.outer][n.cfsFaces])));
+
+  return createAndJoinFaces(definitions);
+}
+
+function mapSurfaceModel(shape, product) {
+  const faceSets = shape[n.items][0][n.fbsmFaces];
+  const definitions = [];
+  faceSets.forEach((faceSet) => definitions.push(...getGeometry(faceSet[n.cfsFaces])));
+
+  return createAndJoinFaces(definitions);
+}
+
+function createAndJoinFaces(definitions) {
   const faces = [];
-  representations.forEach((r) => definitions.push(...getBrepGeometry(r)));
   definitions.forEach((definition) => faces.push(createFace(definition)));
   return joinAllFaces(faces);
 }
@@ -22,10 +35,9 @@ function joinAllFaces(faces) {
   return mesh;
 }
 
-function getBrepGeometry(representation) {
+function getGeometry(faceSet) {
   const faces = [];
-  const ifcFaces = representation[n.outer][n.cfsFaces];
-  ifcFaces.forEach((face) => faces.push(getAllBounds(face)));
+  faceSet.forEach((face) => faces.push(getAllBounds(face)));
   return faces;
 }
 
@@ -61,4 +73,4 @@ function filterBounds(face, type) {
   return face[n.bounds].filter((e) => e[n.ifcClass] === getName(type));
 }
 
-export { mapBrep };
+export { mapBrep, mapSurfaceModel };

--- a/src/ifc-to-three.js/scene/materials.js
+++ b/src/ifc-to-three.js/scene/materials.js
@@ -91,6 +91,10 @@ const materialsMap = {
     material: getTransparentMat(colors.lightBlue, 0),
     lineColor: colors.grey
   },
+  [t.IfcFlowTerminal]: {
+    material: getTransparentMat(colors.lightBlue, 0),
+    lineColor: colors.grey
+  },
   [t.IfcBuildingElementProxy]: {
     material: getDiffuseMat(colors.white),
     lineColor: colors.darkBrown

--- a/src/utils/global-constants.js
+++ b/src/utils/global-constants.js
@@ -14,6 +14,7 @@ const namedProps = {
   elements: "Elements",
   extDirection: "ExtrudedDirection",
   expressId: "_ExpressId",
+  fbsmFaces: "FbsmFaces",
   firstOperand: "FirstOperand",
   geometry: "_Geometry",
   geomRepresentations: "_GeometryRepresentations",
@@ -105,6 +106,7 @@ const geometryTypes = {
   geometricSet: "GeometricSet",
   clipping: "Clipping",
   extrudedAreaSolid: "IfcExtrudedAreaSolid",
+  surfaceModel: "SurfaceModel"
 };
 
 const ifcBoolValues = {


### PR DESCRIPTION
Surface models are mostly processed in the same way as Breps. There are just a few minor differences in the structure of the representation.

It may be a good idea to change the name of icf-brep.js later given that it now also handles surface models, but I couldn't think of a better short name for now. 