### PR TITLE
Adding all remaining missing IFC class definitions for parser

### DIFF
--- a/src/ifc-parser/ifc-models/building-elements.js
+++ b/src/ifc-parser/ifc-models/building-elements.js
@@ -22,6 +22,31 @@ newObject({
 });
 
 newObject({
+  [n.ifcClass]: getName(t.IfcBeam),
+  GlobalId: d.text,
+  OwnerHistory: d.id,
+  Name: d.text,
+  Description: d.text,
+  ObjectType: d.text,
+  [n.objectPlacement]: d.id,
+  [n.representation]: d.id,
+  Tag: d.text
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcFooting),
+  GlobalId: d.text,
+  OwnerHistory: d.id,
+  Name: d.text,
+  Description: d.text,
+  ObjectType: d.text,
+  [n.objectPlacement]: d.id,
+  [n.representation]: d.id,
+  Tag: d.text,
+  PredefinedType: d.enum
+});
+
+newObject({
   [n.ifcClass]: getName(t.IfcWallStandardCase),
   GlobalId: d.text,
   OwnerHistory: d.id,

--- a/src/ifc-parser/ifc-models/geometry.js
+++ b/src/ifc-parser/ifc-models/geometry.js
@@ -177,6 +177,26 @@ newObject({
 });
 
 newObject({
+  [n.ifcClass]: getName(t.IfcSurfaceOfLinearExtrusion),
+  SweptCurve: d.id,
+  Position: d.id,
+  ExtrudedDirection: d.id,
+  Depth: d.number
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcArbitraryOpenProfileDef),
+  ProfileType: d.enum,
+  ProfileName: d.text,
+  Curve: d.id
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcGeometricSet),
+  Elements: d.id
+});
+
+newObject({
   [n.ifcClass]: getName(t.IfcGeometricCurveSet),
   [n.elements]: d.idSet,
 });

--- a/src/ifc-parser/ifc-models/geometry.js
+++ b/src/ifc-parser/ifc-models/geometry.js
@@ -193,7 +193,7 @@ newObject({
 
 newObject({
   [n.ifcClass]: getName(t.IfcGeometricSet),
-  Elements: d.id
+  Elements: d.idSet
 });
 
 newObject({

--- a/src/ifc-parser/ifc-models/presentation.js
+++ b/src/ifc-parser/ifc-models/presentation.js
@@ -28,7 +28,7 @@ newObject({
 newObject({
   [n.ifcClass]: getName(t.IfcFillAreaStyle),
   Name: d.text,
-  FillStyles: d.id
+  FillStyles: d.idSet
 });
 
 newObject({

--- a/src/ifc-parser/ifc-models/presentation.js
+++ b/src/ifc-parser/ifc-models/presentation.js
@@ -34,7 +34,7 @@ newObject({
 newObject({
   [n.ifcClass]: getName(t.IfcFillAreaStyleHatching),
   HatchLineAppearance: d.id,
-  StartOfNextHatchLine: d.id,
+  StartOfNextHatchLine: d.value,
   PointOfReferenceHatchLine: d.id,
   PatternStart: d.id,
   HatchLineAngle: d.number
@@ -43,7 +43,7 @@ newObject({
 newObject({
   [n.ifcClass]: getName(t.IfcCurveStyleFont),
   Name: d.text,
-  PatternList: d.id
+  PatternList: d.idSet
 });
 
 newObject({

--- a/src/ifc-parser/ifc-models/presentation.js
+++ b/src/ifc-parser/ifc-models/presentation.js
@@ -12,6 +12,46 @@ newObject({
 });
 
 newObject({
+  [n.ifcClass]: getName(t.IfcCurveStyleFontPattern),
+  VisibleSegmentLength: d.number,
+  InvisibleSegmentLength: d.number
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcCurveStyle),
+  Name: d.text,
+  CurveFont: d.id,
+  CurveWidth: d.text,
+  CurveColour: d.id
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcFillAreaStyle),
+  Name: d.text,
+  FillStyles: d.id
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcFillAreaStyleHatching),
+  HatchLineAppearance: d.id,
+  StartOfNextHatchLine: d.id,
+  PointOfReferenceHatchLine: d.id,
+  PatternStart: d.id,
+  HatchLineAngle: d.number
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcCurveStyleFont),
+  Name: d.text,
+  PatternList: d.id
+});
+
+newObject({
+  [n.ifcClass]: getName(t.IfcDraughtingPredefinedCurveFont),
+  Name: d.text
+});
+
+newObject({
   [n.ifcClass]: getName(t.IfcMaterialDefinitionRepresentation),
   Name: d.text,
   Description: d.text,

--- a/src/ifc-parser/ifc-models/quantities.js
+++ b/src/ifc-parser/ifc-models/quantities.js
@@ -10,3 +10,13 @@ newObject({
   Unit: d.id,
   AreaValue: d.number,
 });
+
+newObject({
+  [n.ifcClass]: getName(t.IfcElementQuantity),
+  GlobalId: d.text,
+  OwnerHistory: d.id,
+  Name: d.text,
+  Description: d.text,
+  MethodOfMeasurement: d.text,
+  Quantities: d.id
+});

--- a/src/ifc-parser/ifc-models/quantities.js
+++ b/src/ifc-parser/ifc-models/quantities.js
@@ -18,5 +18,5 @@ newObject({
   Name: d.text,
   Description: d.text,
   MethodOfMeasurement: d.text,
-  Quantities: d.id
+  Quantities: d.idSet
 });

--- a/src/utils/ifc-types.js
+++ b/src/utils/ifc-types.js
@@ -1,12 +1,14 @@
 const ifcTypes = {
   //Building elements
   IfcBuildingElementProxy: "IFCBUILDINGELEMENTPROXY",
+  IfcBeam: "IFCBEAM",
   IfcColumn: "IFCCOLUMN",
   IfcCovering: "IFCCOVERING",
   IfcCurtainWall: "IFCCURTAINWALL",
   IfcDoor: "IFCDOOR",
   IfcEquipmentElement: "IFCEQUIPMENTELEMENT",
   IfcFlowTerminal: "IFCFLOWTERMINAL",
+  IfcFooting: "IFCFOOTING",
   IfcFurnishingElement: "IFCFURNISHINGELEMENT",
   IfcMappedItem: "IFCMAPPEDITEM",
   IfcMember: "IFCMEMBER",
@@ -65,6 +67,9 @@ const ifcTypes = {
   IfcRectangleProfileDef: "IFCRECTANGLEPROFILEDEF",
   IfcShapeRepresentation: "IFCSHAPEREPRESENTATION",
   IfcTrimmedCurve: "IFCTRIMMEDCURVE",
+  IfcGeometricSet: "IFCGEOMETRICSET",
+  IfcArbitraryOpenProfileDef: "IFCARBITRARYOPENPROFILEDEF",
+  IfcSurfaceOfLinearExtrusion: "IFCSURFACEOFLINEAREXTRUSION",
   //Identities
   IfcApplication: "IFCAPPLICATION",
   IfcOrganization: "IFCORGANIZATION",
@@ -89,6 +94,12 @@ const ifcTypes = {
   IfcSurfaceStyle: "IFCSURFACESTYLE",
   IfcSurfaceStyleRendering: "IFCSURFACESTYLERENDERING",
   IfcSurfaceStyleShading: "IFCSURFACESTYLESHADING",
+  IfcCurveStyleFontPattern: "IFCCURVESTYLEFONTPATTERN",
+  IfcCurveStyle: "IFCCURVESTYLE",
+  IfcFillAreaStyle: "IFCFILLAREASTYLE",
+  IfcFillAreaStyleHatching: "IFCFILLAREASTYLEHATCHING",
+  IfcCurveStyleFont: "IFCCURVESTYLEFONT",
+  IfcDraughtingPredefinedCurveFont: "IFCDRAUGHTINGPREDEFINEDCURVEFONT",
   //Properties
   IfcBuildingElementProxyType: "IFCBUILDINGELEMENTPROXYTYPE",
   IfcColumnType: "IFCCOLUMNTYPE",
@@ -112,6 +123,7 @@ const ifcTypes = {
   IfcWindowLiningProperties: "IFCWINDOWLININGPROPERTIES",
   //Quantities
   IfcQuantityArea: "IFCQUANTITYAREA",
+  IfcElementQuantity: "IFCELEMENTQUANTITY",
   // Relationships
   IfcRelAggregates: "IFCRELAGGREGATES",
   IfcRelAssignsToGroup: "IFCRELASSIGNSTOGROUP",


### PR DESCRIPTION
I used the IFCOpenShell wrapper to extract the attributes for each class and have created a python script to generate the JS code automatically. This will make life easier when adding IFC4 support. I wasn't sure where to share the generator script, so let me know. 

I've tested using the example IFC files with no issues.